### PR TITLE
Update flash-attn version for compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "lmdb",
         "clip @ git+https://github.com/openai/CLIP.git",
         "mpi4py",
-        "flash-attn",
+        "flash-attn==0.2.8",
         "pillow",
     ],
 )


### PR DESCRIPTION
`FlashAttention()` class doesn't contain `device` parameter in constructor in the latest version. The latest version which has this parameter is `0.2.8`.