### PR TITLE
Fix bug when mixed precision training is set to off by use_fp16 == false

### DIFF
--- a/cm/train_util.py
+++ b/cm/train_util.py
@@ -283,18 +283,20 @@ class CMTrainLoop(TrainLoop):
         self.teacher_model = teacher_model
         self.teacher_diffusion = teacher_diffusion
         self.total_training_steps = total_training_steps
+        self.target_model_master_params = list(self.target_model.parameters())
 
         if target_model:
             self._load_and_sync_target_parameters()
             self.target_model.requires_grad_(False)
             self.target_model.train()
-
-            self.target_model_param_groups_and_shapes = get_param_groups_and_shapes(
-                self.target_model.named_parameters()
-            )
-            self.target_model_master_params = make_master_params(
-                self.target_model_param_groups_and_shapes
-            )
+            if self.use_fp16:
+                self.target_model_param_groups_and_shapes = get_param_groups_and_shapes(
+                    self.target_model.named_parameters()
+                )
+                self.target_model_master_params = make_master_params(
+                    self.target_model_param_groups_and_shapes
+                )
+                self.target_model.convert_to_fp16()
 
         if teacher_model:
             self._load_and_sync_teacher_parameters()
@@ -408,10 +410,11 @@ class CMTrainLoop(TrainLoop):
                 self.mp_trainer.master_params,
                 rate=target_ema,
             )
-            master_params_to_model_params(
-                self.target_model_param_groups_and_shapes,
-                self.target_model_master_params,
-            )
+            if self.use_fp16:
+                master_params_to_model_params(
+                    self.target_model_param_groups_and_shapes,
+                    self.target_model_master_params,
+                )
 
     def reset_training_for_progdist(self):
         assert self.training_mode == "progdist", "Training mode must be progdist"

--- a/cm/train_util.py
+++ b/cm/train_util.py
@@ -287,9 +287,9 @@ class CMTrainLoop(TrainLoop):
 
         if target_model:
             self._load_and_sync_target_parameters()
-            self.target_model.requires_grad_(False)
             self.target_model.train()
             if self.use_fp16:
+                self.target_model.requires_grad_(False)
                 self.target_model_param_groups_and_shapes = get_param_groups_and_shapes(
                     self.target_model.named_parameters()
                 )


### PR DESCRIPTION
1. The original code in train_utils.py only supports for fp16 precision.
2. target_model_master_params will be set as list(target_model.parameters()) if use_fp16 == false.